### PR TITLE
Fix configuration.md typo

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,7 +28,7 @@ default_h2: true
 default_h3: true
 aspect_ratio: "16:9"
 slide_width: 720
-slide_width: 405
+slide_height: 405
 ---
 ```
 


### PR DESCRIPTION
In Default Front Matter section, `slide_width: 405` should be `slide_height: 405`